### PR TITLE
Can now specify whether the height of the views should be set as equal

### DIFF
--- a/Source/NSArray+PureLayout.h
+++ b/Source/NSArray+PureLayout.h
@@ -61,6 +61,9 @@
 /** Distributes the views in this array equally along the selected axis in their superview. Views will be the same size (variable) in the dimension along the axis and will have spacing (fixed) between them, with optional insets from the first and last views to their superview. */
 - (NSArray *)autoDistributeViewsAlongAxis:(ALAxis)axis withFixedSpacing:(CGFloat)spacing insetSpacing:(BOOL)shouldSpaceInsets alignment:(NSLayoutFormatOptions)alignment;
 
+/** Distributes the views in this array equally along the selected axis in their superview. Views will will have spacing (fixed) between them, with optional insets from the first and last views to their superview, and can be constrained to be the same size (or not). */
+- (NSArray *)autoDistributeViewsAlongAxis:(ALAxis)axis withFixedSpacing:(CGFloat)spacing insetSpacing:(BOOL)shouldSpaceInsets alignment:(NSLayoutFormatOptions)alignment matchDimensions:(BOOL)matchDimensions;
+
 /** Distributes the views in this array equally along the selected axis in their superview. Views will be the same size (fixed) in the dimension along the axis and will have spacing (variable) between them. */
 - (NSArray *)autoDistributeViewsAlongAxis:(ALAxis)axis withFixedSize:(CGFloat)size alignment:(NSLayoutFormatOptions)alignment;
 

--- a/Source/NSArray+PureLayout.m
+++ b/Source/NSArray+PureLayout.m
@@ -168,6 +168,23 @@
  */
 - (NSArray *)autoDistributeViewsAlongAxis:(ALAxis)axis withFixedSpacing:(CGFloat)spacing insetSpacing:(BOOL)shouldSpaceInsets alignment:(NSLayoutFormatOptions)alignment
 {
+    return [self autoDistributeViewsAlongAxis:axis withFixedSpacing:spacing insetSpacing:shouldSpaceInsets alignment:alignment matchDimensions:YES];
+}
+
+/**
+ Distributes the views in this array equally along the selected axis in their superview.
+ The size of the views in the passed dimension is controlled by the matchDimensions parameter, and will have spacing (fixed) between them.
+ The first and last views can optionally be inset from their superview by the same amount of spacing as between views.
+ 
+ @param axis The axis along which to distribute the subviews.
+ @param spacing The fixed amount of spacing between each subview.
+ @param shouldSpaceInsets Whether the first and last views should be equally inset from their superview.
+ @param alignment The way in which the subviews will be aligned.
+ @param matchDimensions Whether each view will be constrained to be the same size
+ @return An array of constraints added.
+ */
+- (NSArray *)autoDistributeViewsAlongAxis:(ALAxis)axis withFixedSpacing:(CGFloat)spacing insetSpacing:(BOOL)shouldSpaceInsets alignment:(NSLayoutFormatOptions)alignment matchDimensions:(BOOL)matchDimensions
+{
     NSAssert([self al_containsMinimumNumberOfViews:2], @"This array must contain at least 2 views to distribute.");
     ALDimension matchedDimension;
     ALEdge firstEdge, lastEdge;
@@ -199,7 +216,8 @@
             if (previousView) {
                 // Second, Third, ... View
                 [constraints addObject:[view autoPinEdge:firstEdge toEdge:lastEdge ofView:previousView withOffset:spacing]];
-                [constraints addObject:[view autoMatchDimension:matchedDimension toDimension:matchedDimension ofView:previousView]];
+                if (matchDimensions)
+                    [constraints addObject:[view autoMatchDimension:matchedDimension toDimension:matchedDimension ofView:previousView]];
                 [constraints addObject:[view al_alignToView:previousView withOption:alignment forAxis:axis]];
             }
             else {


### PR DESCRIPTION
I've been using PureLayout in a project recently (a major time saver - thanks) and a couple of times came across some challenges where the default behaviour for `autoDistributeViewsAlongAxis:withFixedSpacing:insetSpacing:alignment:` is trying to make each view the same height. That is often, but not always, the desired behaviour.

On my local fork, I've added the ability to pass a boolean to indicate whether you want the views to be constrained to be the same height.  If this is useful, feel free to pull in... otherwise, just ignore.

Cheers,
Craig
