### PR TITLE
Use UIApplication property to check for right to left layout direction.

### DIFF
--- a/Source/NSArray+PureLayout.m
+++ b/Source/NSArray+PureLayout.m
@@ -358,8 +358,8 @@
             NSAssert(nil, @"Not a valid ALAxis.");
             return nil;
     }
-    BOOL isRightToLeftLanguage = [NSLocale characterDirectionForLanguage:[[NSBundle mainBundle] preferredLocalizations][0]] == NSLocaleLanguageDirectionRightToLeft;
-    BOOL shouldFlipOrder = isRightToLeftLanguage && (axis != ALAxisVertical); // imitate the effect of leading/trailing when distributing horizontally
+    BOOL isRightToLeftLayout = [UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft;
+    BOOL shouldFlipOrder = isRightToLeftLayout && (axis != ALAxisVertical); // imitate the effect of leading/trailing when distributing horizontally
     
     NSMutableArray *constraints = [NSMutableArray new];
     NSArray *views = [self al_copyViewsOnly];


### PR DESCRIPTION
This method to check for RTL layout works with right to left pseudolanguage. Closes #22
