### PR TITLE
Support `ALAttributeFirstBaseline` for OSX 10.11 (EL Capitan)

### DIFF
--- a/PureLayout/PureLayout/ALView+PureLayout.m
+++ b/PureLayout/PureLayout/ALView+PureLayout.m
@@ -795,11 +795,11 @@
             break;
 #if __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11
         case ALAttributeFirstBaseline:
-#if TARGET_IPHONE
+#if TARGET_OS_IPHONE
             NSAssert(__PureLayout_MinSysVer_iOS_8_0, @"ALAttributeFirstBaseline is only supported on iOS 8.0 or higher.");
 #else
             NSAssert(__PureLayout_MinSysVer_OSX_10_11, @"ALAttributeFirstBaseline is only supported on OSX 10.11 or higher.");
-#endif /* TARGET_IPHONE */
+#endif /* TARGET_OS_IPHONE */
             NSAssert(axis != ALAxisVertical, @"Cannot align views that are distributed vertically with ALAttributeFirstBaseline.");
             constraint = [self autoAlignAxis:ALAxisFirstBaseline toSameAxisOfView:otherView];
             break;

--- a/PureLayout/PureLayout/ALView+PureLayout.m
+++ b/PureLayout/PureLayout/ALView+PureLayout.m
@@ -793,13 +793,17 @@
             NSAssert(axis != ALAxisVertical, @"Cannot align views that are distributed vertically with ALAttributeBaseline.");
             constraint = [self autoAlignAxis:ALAxisBaseline toSameAxisOfView:otherView];
             break;
-#if __PureLayout_MinBaseSDK_iOS_8_0
+#if __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11
         case ALAttributeFirstBaseline:
+#if TARGET_IPHONE
             NSAssert(__PureLayout_MinSysVer_iOS_8_0, @"ALAttributeFirstBaseline is only supported on iOS 8.0 or higher.");
+#else
+            NSAssert(__PureLayout_MinSysVer_OSX_10_11, @"ALAttributeFirstBaseline is only supported on OSX 10.11 or higher.");
+#endif /* TARGET_IPHONE */
             NSAssert(axis != ALAxisVertical, @"Cannot align views that are distributed vertically with ALAttributeFirstBaseline.");
             constraint = [self autoAlignAxis:ALAxisFirstBaseline toSameAxisOfView:otherView];
             break;
-#endif /* __PureLayout_MinBaseSDK_iOS_8_0 */
+#endif /* __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11 */
         case ALAttributeTop:
             NSAssert(axis != ALAxisVertical, @"Cannot align views that are distributed vertically with ALAttributeTop.");
             constraint = [self autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:otherView];

--- a/PureLayout/PureLayout/NSArray+PureLayout.m
+++ b/PureLayout/PureLayout/NSArray+PureLayout.m
@@ -292,9 +292,9 @@
     switch (axis) {
         case ALAxisHorizontal:
         case ALAxisBaseline: // same value as ALAxisLastBaseline
-#if __PureLayout_MinBaseSDK_iOS_8_0
+#if __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11
         case ALAxisFirstBaseline:
-#endif /* __PureLayout_MinBaseSDK_iOS_8_0 */
+#endif /* __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11 */
             matchedDimension = ALDimensionWidth;
             firstEdge = ALEdgeLeading;
             lastEdge = ALEdgeTrailing;
@@ -381,9 +381,9 @@
     switch (axis) {
         case ALAxisHorizontal:
         case ALAxisBaseline: // same value as ALAxisLastBaseline
-#if __PureLayout_MinBaseSDK_iOS_8_0
+#if __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11
         case ALAxisFirstBaseline:
-#endif /* __PureLayout_MinBaseSDK_iOS_8_0 */
+#endif /* __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11 */
             fixedDimension = ALDimensionWidth;
             attribute = NSLayoutAttributeCenterX;
             break;

--- a/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.m
+++ b/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.m
@@ -408,11 +408,11 @@ static __NSMutableArray_of(NSString *) *_al_globalConstraintIdentifiers = nil;
             break;
 #if __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11
         case ALAxisFirstBaseline:
-#if TARGET_IPHONE
+#if TARGET_OS_IPHONE
             NSAssert(__PureLayout_MinSysVer_iOS_8_0, @"ALAxisFirstBaseline is only supported on iOS 8.0 or higher.");
 #else
             NSAssert(__PureLayout_MinSysVer_OSX_10_11, @"ALAxisFirstBaseline is only supported on OSX 10.11 or higher.");
-#endif
+#endif /* TARGET_OS_IPHONE */
             layoutAttribute = NSLayoutAttributeFirstBaseline;
             break;
 #endif /* __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11 */

--- a/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.m
+++ b/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.m
@@ -406,11 +406,17 @@ static __NSMutableArray_of(NSString *) *_al_globalConstraintIdentifiers = nil;
         case ALAxisBaseline: // same value as ALAxisLastBaseline
             layoutAttribute = NSLayoutAttributeBaseline;
             break;
-#if __PureLayout_MinBaseSDK_iOS_8_0
+#if __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11
         case ALAxisFirstBaseline:
+#if TARGET_IPHONE
             NSAssert(__PureLayout_MinSysVer_iOS_8_0, @"ALAxisFirstBaseline is only supported on iOS 8.0 or higher.");
+#else
+            NSAssert(__PureLayout_MinSysVer_OSX_10_11, @"ALAxisFirstBaseline is only supported on OSX 10.11 or higher.");
+#endif
             layoutAttribute = NSLayoutAttributeFirstBaseline;
             break;
+#endif /* __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11 */
+#if __PureLayout_MinBaseSDK_iOS_8_0
         case ALMarginLeft:
             NSAssert(__PureLayout_MinSysVer_iOS_8_0, @"ALEdgeLeftMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeLeftMargin;
@@ -465,9 +471,9 @@ static __NSMutableArray_of(NSString *) *_al_globalConstraintIdentifiers = nil;
             break;
         case ALAxisHorizontal:
         case ALAxisBaseline: // same value as ALAxisLastBaseline
-#if __PureLayout_MinBaseSDK_iOS_8_0
+#if __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11
         case ALAxisFirstBaseline:
-#endif /* __PureLayout_MinBaseSDK_iOS_8_0 */
+#endif /* __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11 */
             constraintAxis = ALLayoutConstraintAxisHorizontal;
             break;
         default:

--- a/PureLayout/PureLayout/PureLayoutDefines.h
+++ b/PureLayout/PureLayout/PureLayoutDefines.h
@@ -33,7 +33,12 @@
 // Define some preprocessor macros to check for a minimum Base SDK. These are used to prevent compile-time errors in older versions of Xcode.
 #define __PureLayout_MinBaseSDK_iOS_8_0                   (TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_7_1)
 #define __PureLayout_MinBaseSDK_OSX_10_10                 (!TARGET_OS_IPHONE && __MAC_OS_X_VERSION_MAX_ALLOWED > __MAC_10_9)
+
+#ifdef __MAC_10_11
 #define __PureLayout_MinBaseSDK_OSX_10_11                 (!TARGET_OS_IPHONE && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_11)
+#else
+#define __PureLayout_MinBaseSDK_OSX_10_11                 0
+#endif /* __MAC_10_11 */
 
 // Define some preprocessor macros to check for a minimum System Version. These are used to prevent runtime crashes on older versions of iOS/OS X.
 #define __PureLayout_MinSysVer_iOS_7_0                    (TARGET_OS_IPHONE && floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1)

--- a/PureLayout/PureLayout/PureLayoutDefines.h
+++ b/PureLayout/PureLayout/PureLayoutDefines.h
@@ -33,11 +33,14 @@
 // Define some preprocessor macros to check for a minimum Base SDK. These are used to prevent compile-time errors in older versions of Xcode.
 #define __PureLayout_MinBaseSDK_iOS_8_0                   (TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_7_1)
 #define __PureLayout_MinBaseSDK_OSX_10_10                 (!TARGET_OS_IPHONE && __MAC_OS_X_VERSION_MAX_ALLOWED > __MAC_10_9)
+#define __PureLayout_MinBaseSDK_OSX_10_11                 (!TARGET_OS_IPHONE && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_11)
 
 // Define some preprocessor macros to check for a minimum System Version. These are used to prevent runtime crashes on older versions of iOS/OS X.
 #define __PureLayout_MinSysVer_iOS_7_0                    (TARGET_OS_IPHONE && floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1)
 #define __PureLayout_MinSysVer_iOS_8_0                    (TARGET_OS_IPHONE && floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_7_1)
 #define __PureLayout_MinSysVer_OSX_10_9                   (!TARGET_OS_IPHONE && floor(NSFoundationVersionNumber) > NSFoundationVersionNumber10_8_4)
+#define __PureLayout_MinSysVer_OSX_10_10                   (!TARGET_OS_IPHONE && floor(NSFoundationVersionNumber) > NSFoundationVersionNumber10_9_2)
+#define __PureLayout_MinSysVer_OSX_10_11                   (__PureLayout_MinSysVer_OSX_10_10 && ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10, 11, 0}]))
 
 // Define some preprocessor macros that allow nullability annotations to be adopted in a backwards-compatible manner.
 #if __has_feature(nullability)
@@ -135,10 +138,10 @@ typedef NS_ENUM(NSInteger, ALAxis) {
     ALAxisBaseline = NSLayoutAttributeBaseline,
     /** A horizontal line at the baseline of the last line of text in the view. (For views that do not draw text, will be equivalent to ALEdgeBottom.) */
     ALAxisLastBaseline = ALAxisBaseline,
-    #if __PureLayout_MinBaseSDK_iOS_8_0
+    #if __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11
     /** A horizontal line at the baseline of the first line of text in a view. (For views that do not draw text, will be equivalent to ALEdgeTop.) Available in iOS 8.0 and later. */
     ALAxisFirstBaseline = NSLayoutAttributeFirstBaseline
-    #endif /* __PureLayout_MinBaseSDK_iOS_8_0 */
+    #endif /* __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11 */
 };
 
 #if __PureLayout_MinBaseSDK_iOS_8_0
@@ -196,9 +199,11 @@ typedef NS_ENUM(NSInteger, ALAttribute) {
     ALAttributeBaseline = ALAxisBaseline,
     /** A horizontal line at the baseline of the last line of text in the view. (For views that do not draw text, will be equivalent to ALEdgeBottom.) */
     ALAttributeLastBaseline = ALAxisLastBaseline,
-#if __PureLayout_MinBaseSDK_iOS_8_0
+#if __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11
     /** A horizontal line at the baseline of the first line of text in a view. (For views that do not draw text, will be equivalent to ALEdgeTop.) Available in iOS 8.0 and later. */
     ALAttributeFirstBaseline = ALAxisFirstBaseline,
+#endif /* __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11 */
+#if __PureLayout_MinBaseSDK_iOS_8_0
     /** The left margin of the view, based on the view's layoutMargins left inset. */
     ALAttributeMarginLeft = ALMarginLeft,
     /** The right margin of the view, based on the view's layoutMargins right inset. */

--- a/PureLayout/PureLayoutTests/PureLayoutInternalTests.m
+++ b/PureLayout/PureLayoutTests/PureLayoutInternalTests.m
@@ -43,8 +43,10 @@
     XCTAssert(ALAttributeHorizontal == ALAxisHorizontal);
     XCTAssert(ALAttributeBaseline == ALAxisBaseline);
     XCTAssert(ALAttributeLastBaseline == ALAxisLastBaseline);
-#if __PureLayout_MinBaseSDK_iOS_8_0
+#if __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11
     XCTAssert(ALAttributeFirstBaseline == ALAxisFirstBaseline);
+#endif /* __PureLayout_MinBaseSDK_iOS_8_0 || __PureLayout_MinBaseSDK_OSX_10_11 */
+#if __PureLayout_MinBaseSDK_iOS_8_0
     XCTAssert(ALAttributeMarginLeft == ALMarginLeft);
     XCTAssert(ALAttributeMarginRight == ALMarginRight);
     XCTAssert(ALAttributeMarginTop == ALMarginTop);
@@ -99,6 +101,17 @@
         XCTAssert([NSLayoutConstraint al_layoutAttributeForAttribute:(ALAttribute)ALAxisLastBaseline] == NSLayoutAttributeLastBaseline, @"ALAxisLastBaseline should correspond to NSLayoutAttributeLastBaseline.");
     }
 #endif /* __PureLayout_MinBaseSDK_iOS_8_0 */
+    
+#if __PureLayout_MinBaseSDK_OSX_10_11
+    if (__PureLayout_MinSysVer_OSX_10_11) {
+        XCTAssert([NSLayoutConstraint al_layoutAttributeForAttribute:(ALAttribute)ALAxisLastBaseline] == NSLayoutAttributeLastBaseline, @"ALAxisLastBaseline should correspond to NSLayoutAttributeLastBaseline.");
+        XCTAssert([NSLayoutConstraint al_layoutAttributeForAttribute:(ALAttribute)ALAxisFirstBaseline] == NSLayoutAttributeFirstBaseline, @"ALAxisFirstBaseline should correspond to NSLayoutAttributeFirstBaseline.");
+    } else {
+        XCTAssertThrows([NSLayoutConstraint al_layoutAttributeForAttribute:(ALAttribute)ALAxisFirstBaseline], @"ALAxisFirstBaseline should throw an exception on OSX 10.10 or earlier.");
+        XCTAssertNoThrow([NSLayoutConstraint al_layoutAttributeForAttribute:(ALAttribute)ALAxisLastBaseline], @"ALAxisLastBaseline should not throw an exception on iOS 6 or 7.");
+        XCTAssert([NSLayoutConstraint al_layoutAttributeForAttribute:(ALAttribute)ALAxisLastBaseline] == NSLayoutAttributeLastBaseline, @"ALAxisLastBaseline should correspond to NSLayoutAttributeLastBaseline.");
+    }
+#endif /* __PureLayout_MinBaseSDK_OSX_10_11 */
     
     XCTAssertThrows([NSLayoutConstraint al_layoutAttributeForAttribute:(ALAttribute)NSLayoutAttributeNotAnAttribute], @"Passing an invalid ALAttribute should throw an exception.");
 }


### PR DESCRIPTION
- PureLayout/PureLayout/ALView+PureLayout.m

(-[ALView al_alignAttribute:toView:]): Enable branch of `case ALAttributeFirstBaseline` for both iOS 8.0+ and OSX 10.11
- PureLayout/PureLayout/NSArray+PureLayout.m

(-[NSArray autoDistributeViewsAlongAxis:alignedTo:withFixedSpacing:insetSpacing:matchedSizes:]):
(-[NSArray autoDistributeViewsAlongAxis:alignedTo:withFixedSize:insetSpacing:]): Enable branch of `case ALAxisFirstBaseline` for both iOS 8.0+ and OSX 10.11
- PureLayout/PureLayout/NSLayoutConstraint+PureLayout.m

(-[NSLayoutConstraint al_layoutAttributeForAttribute:]):
(-[NSLayoutConstraint al_constraintAxisForAxis:]): Enable brance of `case ALAxisFirstBaseline` for both iOS 8.0+ and OSX 10.11
- PureLayout/PureLayout/PureLayoutDefines.h

Add macros of `__PureLayout_MinBaseSDK_OSX_10_11`, `__PureLayout_MinSysVer_OSX_10_10` and `__PureLayout_MinSysVer_OSX_10_11`
- PureLayout/PureLayoutTests/PureLayoutInternalTests.m

(-[PureLayoutInternalTests testAttributeEnums]): Test equality of `ALAttributeFirstBaseline` and `ALAxisFirstBaseline` for both iOS 8.0+ and OSX 10.11
(-[PureLayoutInternalTests testLayoutAttributeForAttribute]): Test `-[NSLayoutConstraint al_layoutAttributeForAttribute:ALAxisLastBaseline]` and `-[NSLayoutConstraint al_layoutAttributeForAttribute:(ALAttribute)ALAxisFirstBaseline]` for both iOS 8.0+ and OSX 10.11
