### PR TITLE
Add method to distribute views with an array of spacings

### DIFF
--- a/PureLayout/PureLayout/NSArray+PureLayout.h
+++ b/PureLayout/PureLayout/NSArray+PureLayout.h
@@ -96,6 +96,34 @@ __PL_ASSUME_NONNULL_BEGIN
                                                      insetSpacing:(BOOL)shouldSpaceInsets
                                                      matchedSizes:(BOOL)shouldMatchSizes;
 
+/** Distributes the views in this array equally along the selected axis in their superview.
+ Views will have spacing (fixed) between them, with optional insets equal to insetSpacing from the first and last views to their superview. */
+- (__NSArray_of(NSLayoutConstraint *) *)autoDistributeViewsAlongAxis:(ALAxis)axis
+                                                           alignedTo:(ALAttribute)alignment
+                                                        withFixedSpacing:(CGFloat)spacing
+                                                   insetFixedSpacing:(CGFloat)insetSpacing;
+
+/** Distributes the views in this array equally along the selected axis in their superview.
+ Views will have spacing (fixed) between them, with optional insets equal to insetSpacing from the first and last views to their superview, and optionally constrained to the same size in the dimension along the axis. */
+- (__NSArray_of(NSLayoutConstraint *) *)autoDistributeViewsAlongAxis:(ALAxis)axis
+                                                           alignedTo:(ALAttribute)alignment
+                                                    withFixedSpacing:(CGFloat)spacing
+                                                   insetFixedSpacing:(CGFloat)insetSpacing                                                      matchedSized:(BOOL)shouldMatchSizes;
+
+
+/** Distributes the views in this array with provided spacings along the selected axis in their superview.
+ Views will have spacings as supplied, starting with the inset from the first view to the superview and proceeding to the right until the last view and the superview. The views will be constrained to the same size(variable) in the dimension along the axis. */
+- (__NSArray_of(NSLayoutConstraint *) *)autoDistributeViewsAlongAxis:(ALAxis)axis
+                                                           alignedTo:(ALAttribute)alignment
+                                                        withSpacings:(__NSArray_of(NSNumber *) *)spacings;
+
+/** Distributes the views in this array with provided spacings along the selected axis in their superview.
+ Views will have spacings as supplied, starting with the inset from the first view to the superview and proceeding to the right until the last view and the superview. The views will be optionally constrained to the same size(variable) in the dimension along the axis. */
+- (__NSArray_of(NSLayoutConstraint *) *)autoDistributeViewsAlongAxis:(ALAxis)axis
+                                                           alignedTo:(ALAttribute)alignment
+                                                        withSpacings:(__NSArray_of(NSNumber *) *)spacings
+                                                        matchedSizes:(BOOL)shouldMatchSizes;
+
 
 /** Distributes the views in this array equally along the selected axis in their superview.
     Views will be the same size (fixed) in the dimension along the axis and will have spacing (variable) between them. */

--- a/PureLayout/PureLayout/NSArray+PureLayout.m
+++ b/PureLayout/PureLayout/NSArray+PureLayout.m
@@ -389,8 +389,8 @@ Views will have spacings as supplied, starting with the inset from the first vie
             NSAssert(nil, @"Not a valid ALAxis.");
             return nil;
     }
-    CGFloat leadingSpacing = (CGFloat) spacings.firstObject.floatValue;
-    CGFloat trailingSpacing = (CGFloat) spacings.lastObject.floatValue;
+    CGFloat leadingSpacing = (CGFloat) [[spacings firstObject] floatValue];
+    CGFloat trailingSpacing = (CGFloat) [[spacings lastObject] floatValue];
     
     __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     ALView *previousView = nil;
@@ -401,7 +401,7 @@ Views will have spacings as supplied, starting with the inset from the first vie
             view.translatesAutoresizingMaskIntoConstraints = NO;
             if (previousView) {
                 // Second, Third, ... View
-                CGFloat spacing = (CGFloat) spacings[index].floatValue;
+                CGFloat spacing = (CGFloat) [spacings[index] floatValue];
                 [constraints addObject:[view autoPinEdge:firstEdge toEdge:lastEdge ofView:previousView withOffset:spacing]];
                 if (shouldMatchSizes) {
                     [constraints addObject:[view autoMatchDimension:matchedDimension toDimension:matchedDimension ofView:previousView]];

--- a/PureLayout/PureLayoutTests/PureLayoutDistributeTests.m
+++ b/PureLayout/PureLayoutTests/PureLayoutDistributeTests.m
@@ -67,6 +67,78 @@
     [constraints autoRemoveConstraints];
 }
 
+- (void)testAutoDistributeViewsHorizontallyWithProvidedSpacings
+{
+    __NSArray_of(NSLayoutConstraint *) *constraints = nil;
+    __NSMutableArray_of(NSNumber *) * spacings = [NSMutableArray arrayWithCapacity:self.viewArray.count + 1];
+    float spacingSum = 0.0;
+    for(int i=0; i < self.viewArray.count + 1; i++){
+        float spacing = (i+3.0) * 2.0;
+        spacingSum += spacing;
+        [spacings addObject:[NSNumber numberWithFloat:spacing]];
+    }
+    constraints = [self.viewArray autoDistributeViewsAlongAxis:ALAxisHorizontal alignedTo:ALAttributeTop withSpacings:spacings matchedSizes:YES];
+    [self evaluateConstraints];
+    
+    CGFloat containerWidth = self.containerView.frame.size.width;
+    float expectedWidth = (containerWidth - spacingSum) / ((float) self.viewArray.count);
+
+    CGFloat previousEdge = 0.0;
+    int i = 0;
+    for(ALView * view in self.viewArray){
+        CGFloat x = view.frame.origin.x;
+        CGFloat spacing = x - previousEdge;
+        previousEdge = x + view.frame.size.width;
+        float plannedSpacing = spacings[i].floatValue;
+        XCTAssert(ROUNDED_EQUALS(plannedSpacing, spacing));
+        //check if all views have almost the same width
+        ALAssertWidthEquals(view, expectedWidth);
+        i++;
+    }
+    XCTAssert(ROUNDED_EQUALS(previousEdge + spacings.lastObject.floatValue, containerWidth));
+    
+    [constraints autoRemoveConstraints];
+}
+
+- (void)testAutoDistributeViewsVerticallyWithProvidedSpacings
+{
+    __NSArray_of(ALView *) * views = self.viewArray;
+    __NSArray_of(NSLayoutConstraint *) *constraints = nil;
+    __NSMutableArray_of(NSNumber *) * spacingsMutable = [NSMutableArray arrayWithCapacity:views.count + 1];
+    float spacingSum = 0.0;
+    for(int i=0; i < views.count + 1; i++){
+        float spacing = (i+4.0) * 3.0;
+        spacingSum += spacing;
+        [spacingsMutable addObject:[NSNumber numberWithFloat:spacing]];
+    }
+    __NSArray_of(NSNumber *) * spacings = spacingsMutable;
+    
+    constraints = [views autoDistributeViewsAlongAxis:ALAxisVertical alignedTo:ALAttributeRight withSpacings:spacings matchedSizes:YES];
+    [self evaluateConstraints];
+    
+#if !TARGET_OS_IPHONE
+    views = [[views reverseObjectEnumerator] allObjects];
+    spacings = [[spacings reverseObjectEnumerator] allObjects];
+#endif
+    
+    CGFloat containerHeight = self.containerView.frame.size.height;
+    CGFloat previousEdge =  0.0;
+    float expectedHeight = (containerHeight - spacingSum) / ((float) self.viewArray.count);
+    int i = 0;
+    for(ALView * view in views){
+        CGFloat y = view.frame.origin.y;
+        CGFloat spacing = y - previousEdge;
+        previousEdge = y + view.frame.size.height; 
+        float plannedSpacing = spacings[i].floatValue;
+        XCTAssert(ROUNDED_EQUALS(plannedSpacing, spacing));
+        ALAssertHeightEquals(view, expectedHeight);
+        i++;
+    }
+    XCTAssert(ROUNDED_EQUALS(previousEdge + spacings.lastObject.floatValue, containerHeight));
+    
+    [constraints autoRemoveConstraints];
+}
+
 - (void)testAutoDistributeViewsHorizontallyWithFixedSize
 {
     __NSArray_of(NSLayoutConstraint *) *constraints = nil;

--- a/PureLayout/PureLayoutTests/PureLayoutDistributeTests.m
+++ b/PureLayout/PureLayoutTests/PureLayoutDistributeTests.m
@@ -89,13 +89,13 @@
         CGFloat x = view.frame.origin.x;
         CGFloat spacing = x - previousEdge;
         previousEdge = x + view.frame.size.width;
-        float plannedSpacing = spacings[i].floatValue;
+        float plannedSpacing = [spacings[i] floatValue];
         XCTAssert(ROUNDED_EQUALS(plannedSpacing, spacing));
         //check if all views have almost the same width
         ALAssertWidthEquals(view, expectedWidth);
         i++;
     }
-    XCTAssert(ROUNDED_EQUALS(previousEdge + spacings.lastObject.floatValue, containerWidth));
+    XCTAssert(ROUNDED_EQUALS(previousEdge + [[spacings lastObject] floatValue], containerWidth));
     
     [constraints autoRemoveConstraints];
 }
@@ -129,12 +129,12 @@
         CGFloat y = view.frame.origin.y;
         CGFloat spacing = y - previousEdge;
         previousEdge = y + view.frame.size.height; 
-        float plannedSpacing = spacings[i].floatValue;
+        float plannedSpacing = [spacings[i] floatValue];
         XCTAssert(ROUNDED_EQUALS(plannedSpacing, spacing));
         ALAssertHeightEquals(view, expectedHeight);
         i++;
     }
-    XCTAssert(ROUNDED_EQUALS(previousEdge + spacings.lastObject.floatValue, containerHeight));
+    XCTAssert(ROUNDED_EQUALS(previousEdge + [[spacings lastObject] floatValue], containerHeight));
     
     [constraints autoRemoveConstraints];
 }

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Additionally, there is one generic attribute type, `ALAttribute`, which is effec
 - autoSetViewsDimension:toSize:
 - autoSetViewsDimensionsToSize:
 - autoDistributeViewsAlongAxis:alignedTo:withFixedSpacing:(insetSpacing:)(matchedSizes:)
+- autoDistributeViewsAlongAxis:alignedTo:withSpacings:(matchedSizes:)
+- autoDistributeViewsAlongAxis:alignedTo:withFixedSpacing:insetFixedSpacing:(matchedSizes:)
 - autoDistributeViewsAlongAxis:alignedTo:withFixedSize:(insetSpacing:)
 ```
 


### PR DESCRIPTION
Hi,
I needed a method to distribute views with fixed spacings between them, but with inset spacings being different. Before the library allowed only fixed spacing everywhere of inset spacing = 0.
I did add a method where you can provide an array of spacings (size equal to number of views + 1) and based previous methods on that. 
Also added one where you can provide fixed spacing and inset fixed spacing.

Cheers,
Michal

---------------------------
Methods added:
1. autoDistributeViewsAlongAxis:(ALAxis)axis alignedTo:(ALAttribute)alignment withSpacings:(__NSArray_of(NSNumber *) *)spacings matchedSizes:(BOOL)shouldMatchSizes.
2. autoDistributeViewsAlongAxis:(ALAxis)axis alignedTo:(ALAttribute)alignment withFixedSpacing:(CGFloat)spacing insetFixedSpacing:(CGFloat)insetSpacing matchedSized:(BOOL)shouldMatchSizes
3. Utility method al_numberOfViews to count the number of views in an array. 

No. 1 allows to distribute the views along selected axis with custom spacings between superview and the views.
No. 2 allows to distribute the views with fixed spacing between them and different fixed spacing between edge views and superview.

Tests added for no. 1 as it is more generic.