### PR TITLE
Space constraints

### DIFF
--- a/PureLayout/PureLayout/ALView+PureLayout.h
+++ b/PureLayout/PureLayout/ALView+PureLayout.h
@@ -121,16 +121,16 @@ __PL_ASSUME_NONNULL_BEGIN
 - (NSLayoutConstraint *)autoPinEdge:(ALEdge)edge toEdge:(ALEdge)toEdge ofView:(ALView *)otherView withOffset:(CGFloat)offset relation:(NSLayoutRelation)relation;
 
 /** Pin a space between self and the other view [self]-space-[otherView], either on the horizontal or vertical axis. */
-- (NSLayoutConstraint *)autoPinSpace:(CGFloat)space toView:(ALView *)otherView onAxis:(ALAxis)axis;
+- (NSLayoutConstraint *)autoPinSpace:(CGFloat)space followedByView:(ALView *)otherView onAxis:(ALAxis)axis;
 
 /** Pin a space between self and the other view [self]-space-[otherView], either on the horizontal or vertical axis with the space as a maximum or minimum.  */
-- (NSLayoutConstraint *)autoPinSpace:(CGFloat)space toView:(ALView *)otherView onAxis:(ALAxis)axis relation:(NSLayoutRelation)relation;
+- (NSLayoutConstraint *)autoPinSpace:(CGFloat)space followedByView:(ALView *)otherView onAxis:(ALAxis)axis relation:(NSLayoutRelation)relation;
 
 /** Pin trailing to leading with a space H:[self]-space-[otherView] */
-- (NSLayoutConstraint *)autoPinHorizontalSpace:(CGFloat)space toView:(ALView *)otherView;
+- (NSLayoutConstraint *)autoPinHorizontalSpace:(CGFloat)space followedByView:(ALView *)otherView;
 
 /** Pin bottom to top with a space V:[self]-space-[otherView] */
-- (NSLayoutConstraint *)autoPinVerticalSpace:(CGFloat)space toView:(ALView *)otherView;
+- (NSLayoutConstraint *)autoPinVerticalSpace:(CGFloat)space followedByView:(ALView *)otherView;
 
 /** Pin all 4 edges to another view, so that they will have the same frame. */
 - (__NSArray_of(NSLayoutConstraint *) *)autoPinAllEdgesToView:(ALView *)otherView;

--- a/PureLayout/PureLayout/ALView+PureLayout.h
+++ b/PureLayout/PureLayout/ALView+PureLayout.h
@@ -50,6 +50,8 @@ __PL_ASSUME_NONNULL_BEGIN
 /** Configures an existing view to not convert the autoresizing mask into constraints and returns the view. */
 - (instancetype)configureForAutoLayout;
 
+/* Adds the subview and also configures the view to not convert the autoresizing mask into constraints */
+- (void)addSubviewWithAutoLayout:(UIView *)subview;
 
 #pragma mark Center & Align in Superview
 
@@ -118,6 +120,20 @@ __PL_ASSUME_NONNULL_BEGIN
 /** Pins an edge of the view to a given edge of another view with an offset as a maximum or minimum. */
 - (NSLayoutConstraint *)autoPinEdge:(ALEdge)edge toEdge:(ALEdge)toEdge ofView:(ALView *)otherView withOffset:(CGFloat)offset relation:(NSLayoutRelation)relation;
 
+/** Pin a space between self and the other view [self]-space-[otherView], either on the horizontal or vertical axis. */
+- (NSLayoutConstraint *)autoPinSpace:(CGFloat)space toView:(ALView *)otherView onAxis:(ALAxis)axis;
+
+/** Pin a space between self and the other view [self]-space-[otherView], either on the horizontal or vertical axis with the space as a maximum or minimum.  */
+- (NSLayoutConstraint *)autoPinSpace:(CGFloat)space toView:(ALView *)otherView onAxis:(ALAxis)axis relation:(NSLayoutRelation)relation;
+
+/** Pin trailing to leading with a space H:[self]-space-[otherView] */
+- (NSLayoutConstraint *)autoPinHorizontalSpace:(CGFloat)space toView:(ALView *)otherView;
+
+/** Pin bottom to top with a space V:[self]-space-[otherView] */
+- (NSLayoutConstraint *)autoPinVerticalSpace:(CGFloat)space toView:(ALView *)otherView;
+
+/** Pin all 4 edges to another view, so that they will have the same frame. */
+- (__NSArray_of(NSLayoutConstraint *) *)autoPinAllEdgesToView:(ALView *)otherView;
 
 #pragma mark Align Axes
 
@@ -130,6 +146,7 @@ __PL_ASSUME_NONNULL_BEGIN
 /** Aligns an axis of the view to the same axis of another view with a multiplier. */
 - (NSLayoutConstraint *)autoAlignAxis:(ALAxis)axis toSameAxisOfView:(ALView *)otherView withMultiplier:(CGFloat)multiplier;
 
+- (__NSArray_of(NSLayoutConstraint *) *)autoAlignBothAxisToView:(ALView *)otherView;
 
 #pragma mark Match Dimensions
 

--- a/PureLayout/PureLayout/ALView+PureLayout.m
+++ b/PureLayout/PureLayout/ALView+PureLayout.m
@@ -367,7 +367,7 @@
     return [self autoConstrainAttribute:(ALAttribute)edge toAttribute:(ALAttribute)toEdge ofView:otherView withOffset:offset relation:relation];
 }
 
-- (NSLayoutConstraint *)autoPinSpace:(CGFloat)space toView:(ALView *)otherView onAxis:(ALAxis)axis relation:(NSLayoutRelation)relation
+- (NSLayoutConstraint *)autoPinSpace:(CGFloat)space followedByView:(ALView *)otherView onAxis:(ALAxis)axis relation:(NSLayoutRelation)relation
 {
     NSLayoutAttribute leadingAttribute;
     NSLayoutAttribute trailingAttribute;
@@ -385,19 +385,19 @@
     return constraint;
 }
 
-- (NSLayoutConstraint *)autoPinSpace:(CGFloat)space toView:(ALView *)otherView onAxis:(ALAxis)axis
+- (NSLayoutConstraint *)autoPinSpace:(CGFloat)space followedByView:(ALView *)otherView onAxis:(ALAxis)axis
 {
-    return [self autoPinSpace:space toView:otherView onAxis:axis relation:NSLayoutRelationEqual];
+    return [self autoPinSpace:space followedByView:otherView onAxis:axis relation:NSLayoutRelationEqual];
 }
 
-- (NSLayoutConstraint *)autoPinHorizontalSpace:(CGFloat)space toView:(ALView *)otherView
+- (NSLayoutConstraint *)autoPinHorizontalSpace:(CGFloat)space followedByView:(ALView *)otherView
 {
-    return [self autoPinSpace:space toView:otherView onAxis:ALAxisHorizontal relation:NSLayoutRelationEqual];
+    return [self autoPinSpace:space followedByView:otherView onAxis:ALAxisHorizontal relation:NSLayoutRelationEqual];
 }
 
-- (NSLayoutConstraint *)autoPinVerticalSpace:(CGFloat)space toView:(ALView *)otherView
+- (NSLayoutConstraint *)autoPinVerticalSpace:(CGFloat)space followedByView:(ALView *)otherView
 {
-    return [self autoPinSpace:space toView:otherView onAxis:ALAxisVertical relation:NSLayoutRelationEqual];
+    return [self autoPinSpace:space followedByView:otherView onAxis:ALAxisVertical relation:NSLayoutRelationEqual];
 }
 
 - (__NSArray_of(NSLayoutConstraint *) *)autoPinAllEdgesToView:(ALView *)otherView

--- a/PureLayout/PureLayout/ALView+PureLayout.m
+++ b/PureLayout/PureLayout/ALView+PureLayout.m
@@ -71,6 +71,13 @@
 }
 
 
+- (void)addSubviewWithAutoLayout:(UIView *)subview
+{
+    subview.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:subview];
+}
+
+
 #pragma mark Center in Superview
 
 /**
@@ -360,6 +367,49 @@
     return [self autoConstrainAttribute:(ALAttribute)edge toAttribute:(ALAttribute)toEdge ofView:otherView withOffset:offset relation:relation];
 }
 
+- (NSLayoutConstraint *)autoPinSpace:(CGFloat)space toView:(ALView *)otherView onAxis:(ALAxis)axis relation:(NSLayoutRelation)relation
+{
+    NSLayoutAttribute leadingAttribute;
+    NSLayoutAttribute trailingAttribute;
+    if (axis == ALAxisVertical) {
+        leadingAttribute = NSLayoutAttributeTop;
+        trailingAttribute = NSLayoutAttributeBottom;
+    } else {
+        leadingAttribute = NSLayoutAttributeLeading;
+        trailingAttribute = NSLayoutAttributeTrailing;
+    }
+    // These need to be formulated differently, with the otherView first, for the constant to be positive
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+    NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:otherView attribute:leadingAttribute relatedBy:relation toItem:self attribute:trailingAttribute multiplier:1.0 constant:space];
+    [constraint autoInstall];
+    return constraint;
+}
+
+- (NSLayoutConstraint *)autoPinSpace:(CGFloat)space toView:(ALView *)otherView onAxis:(ALAxis)axis
+{
+    return [self autoPinSpace:space toView:otherView onAxis:axis relation:NSLayoutRelationEqual];
+}
+
+- (NSLayoutConstraint *)autoPinHorizontalSpace:(CGFloat)space toView:(ALView *)otherView
+{
+    return [self autoPinSpace:space toView:otherView onAxis:ALAxisHorizontal relation:NSLayoutRelationEqual];
+}
+
+- (NSLayoutConstraint *)autoPinVerticalSpace:(CGFloat)space toView:(ALView *)otherView
+{
+    return [self autoPinSpace:space toView:otherView onAxis:ALAxisVertical relation:NSLayoutRelationEqual];
+}
+
+- (__NSArray_of(NSLayoutConstraint *) *)autoPinAllEdgesToView:(ALView *)otherView
+{
+    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    [constraints addObject:[self autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:otherView]];
+    [constraints addObject:[self autoPinEdge:ALEdgeBottom toEdge:ALEdgeBottom ofView:otherView]];
+    [constraints addObject:[self autoPinEdge:ALEdgeLeading toEdge:ALEdgeLeading ofView:otherView]];
+    [constraints addObject:[self autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:otherView]];
+    return constraints;
+}
+
 
 #pragma mark Align Axes
 
@@ -401,6 +451,13 @@
     return [self autoConstrainAttribute:(ALAttribute)axis toAttribute:(ALAttribute)axis ofView:otherView withMultiplier:multiplier];
 }
 
+- (__NSArray_of(NSLayoutConstraint *) *)autoAlignBothAxisToView:(ALView *)otherView
+{
+    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    [constraints addObject:[self autoAlignAxis:ALAxisHorizontal toSameAxisOfView:otherView]];
+    [constraints addObject:[self autoAlignAxis:ALAxisVertical toSameAxisOfView:otherView]];
+    return constraints;
+}
 
 #pragma mark Match Dimensions
 

--- a/PureLayout/PureLayout/ALView+PureLayout.m
+++ b/PureLayout/PureLayout/ALView+PureLayout.m
@@ -179,13 +179,13 @@
     ALView *superview = self.superview;
     NSAssert(superview, @"View's superview must not be nil.\nView: %@", self);
     if (edge == ALEdgeBottom || edge == ALEdgeRight || edge == ALEdgeTrailing) {
-        // The bottom, right, and trailing insets (and relations, if an inequality) are inverted to become offsets
-        inset = -inset;
-        if (relation == NSLayoutRelationLessThanOrEqual) {
-            relation = NSLayoutRelationGreaterThanOrEqual;
-        } else if (relation == NSLayoutRelationGreaterThanOrEqual) {
-            relation = NSLayoutRelationLessThanOrEqual;
-        }
+        // This must be formulated a bit differently, with the superview first, in order to keep the constant
+        // positive.
+        self.translatesAutoresizingMaskIntoConstraints = NO;
+        NSLayoutAttribute edgeAttribute = [NSLayoutConstraint al_layoutAttributeForAttribute:(ALAttribute)edge];
+        NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:superview attribute:edgeAttribute relatedBy:relation toItem:self attribute:edgeAttribute multiplier:1.0 constant:inset];
+        [constraint autoInstall];
+        return constraint;
     }
     return [self autoPinEdge:edge toEdge:edge ofView:superview withOffset:inset relation:relation];
 }


### PR DESCRIPTION
This adds convenience methods for the common case of two child views separated by some space. They are common enough that the Auto Format Format Language was specially suited to them, with the format "[red]-[blue]".

These are a little tricky to create by hand if you want the constant space to be positive. For example, `[orange]-5-[black]` is `black.leading = orange.trailing + 5`. The black view comes first in the equation. This requires a moment of pause every time I write the constraint by hand. `[orange autoPinHorizontalSpace:5 followedByView:black]` is more natural.

This PR also fixes a bug in `autoPinEdgeToSuperviewEdge: withInset: relation:` so the constant is always positive and it prints in the debugger using the Auto Layout Format Language. If it is too risky I can remove it from this PR.