### PR TITLE
adding noescape attribute to ALConstraintsBlock arguments, as they do not escape

### DIFF
--- a/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.h
+++ b/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.h
@@ -43,18 +43,18 @@ PL__ASSUME_NONNULL_BEGIN
 /** Creates all of the constraints in the block, then installs (activates) them all at once.
     All constraints created from calls to the PureLayout API in the block are returned in a single array.
     This may be more efficient than installing (activating) each constraint one-by-one. */
-+ (PL__NSArray_of(NSLayoutConstraint *) *)autoCreateAndInstallConstraints:(ALConstraintsBlock)block;
++ (PL__NSArray_of(NSLayoutConstraint *) *)autoCreateAndInstallConstraints:(__attribute__((noescape)) ALConstraintsBlock)block;
 
 /** Creates all of the constraints in the block but prevents them from being automatically installed (activated).
     All constraints created from calls to the PureLayout API in the block are returned in a single array. */
-+ (PL__NSArray_of(NSLayoutConstraint *) *)autoCreateConstraintsWithoutInstalling:(ALConstraintsBlock)block;
++ (PL__NSArray_of(NSLayoutConstraint *) *)autoCreateConstraintsWithoutInstalling:(__attribute__((noescape)) ALConstraintsBlock)block;
 
 
 #pragma mark Set Priority For Constraints
 
 /** Sets the constraint priority to the given value for all constraints created using the PureLayout API within the given constraints block.
     NOTE: This method will have no effect (and will NOT set the priority) on constraints created or added without using the PureLayout API! */
-+ (void)autoSetPriority:(ALLayoutPriority)priority forConstraints:(ALConstraintsBlock)block;
++ (void)autoSetPriority:(ALLayoutPriority)priority forConstraints:(__attribute__((noescape)) ALConstraintsBlock)block;
 
 
 #pragma mark Identify Constraints
@@ -63,7 +63,7 @@ PL__ASSUME_NONNULL_BEGIN
 
 /** Sets the identifier for all constraints created using the PureLayout API within the given constraints block.
     NOTE: This method will have no effect (and will NOT set the identifier) on constraints created or added without using the PureLayout API! */
-+ (void)autoSetIdentifier:(NSString *)identifier forConstraints:(ALConstraintsBlock)block;
++ (void)autoSetIdentifier:(NSString *)identifier forConstraints:(__attribute__((noescape)) ALConstraintsBlock)block;
 
 /** Sets the string as the identifier for this constraint. Available in iOS 7.0 and OS X 10.9 and later. */
 - (instancetype)autoIdentify:(NSString *)identifier;

--- a/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.m
+++ b/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.m
@@ -95,7 +95,7 @@ static BOOL _al_isInstallingCreatedConstraints = NO;
  @param block A block of method calls to the PureLayout API that create constraints.
  @return An array of the constraints that were created from calls to the PureLayout API inside the block.
  */
-+ (PL__NSArray_of(NSLayoutConstraint *) *)autoCreateAndInstallConstraints:(ALConstraintsBlock)block
++ (PL__NSArray_of(NSLayoutConstraint *) *)autoCreateAndInstallConstraints:(__attribute__((noescape)) ALConstraintsBlock)block
 {
     NSArray *createdConstraints = [self autoCreateConstraintsWithoutInstalling:block];
     _al_isInstallingCreatedConstraints = YES;
@@ -114,7 +114,7 @@ static BOOL _al_isInstallingCreatedConstraints = NO;
  @param block A block of method calls to the PureLayout API that create constraints.
  @return An array of the constraints that were created from calls to the PureLayout API inside the block.
  */
-+ (PL__NSArray_of(NSLayoutConstraint *) *)autoCreateConstraintsWithoutInstalling:(ALConstraintsBlock)block
++ (PL__NSArray_of(NSLayoutConstraint *) *)autoCreateConstraintsWithoutInstalling:(__attribute__((noescape)) ALConstraintsBlock)block
 {
     NSAssert(block, @"The constraints block cannot be nil.");
     NSArray *createdConstraints = nil;
@@ -184,7 +184,7 @@ static __NSMutableArray_of(NSNumber *) *_al_globalConstraintPriorities = nil;
  @param priority The layout priority to be set on all constraints created in the constraints block.
  @param block A block of method calls to the PureLayout API that create and install constraints.
  */
-+ (void)autoSetPriority:(ALLayoutPriority)priority forConstraints:(ALConstraintsBlock)block
++ (void)autoSetPriority:(ALLayoutPriority)priority forConstraints:(__attribute__((noescape)) ALConstraintsBlock)block
 {
     NSAssert(block, @"The constraints block cannot be nil.");
     if (block) {
@@ -244,7 +244,7 @@ static __NSMutableArray_of(NSString *) *_al_globalConstraintIdentifiers = nil;
  @param identifier A string used to identify all constraints created in the constraints block.
  @param block A block of method calls to the PureLayout API that create and install constraints.
  */
-+ (void)autoSetIdentifier:(NSString *)identifier forConstraints:(ALConstraintsBlock)block
++ (void)autoSetIdentifier:(NSString *)identifier forConstraints:(__attribute__((noescape)) ALConstraintsBlock)block
 {
     NSAssert(block, @"The constraints block cannot be nil.");
     NSAssert(identifier, @"The identifier string cannot be nil.");


### PR DESCRIPTION
Adding the `__attribute__((noescape))` annotations to the `ALConstraintsBlock`.  They do not escape and this annotation allows the omission of `self` in Swift closures.