### PR TITLE
Compiler warnings

### DIFF
--- a/PureLayout/PureLayout/ALView+PureLayout.m
+++ b/PureLayout/PureLayout/ALView+PureLayout.m
@@ -80,7 +80,7 @@
  */
 - (PL__NSArray_of(NSLayoutConstraint *) *)autoCenterInSuperview
 {
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     [constraints addObject:[self autoAlignAxisToSuperviewAxis:ALAxisHorizontal]];
     [constraints addObject:[self autoAlignAxisToSuperviewAxis:ALAxisVertical]];
     return constraints;
@@ -109,7 +109,7 @@
  */
 - (PL__NSArray_of(NSLayoutConstraint *) *)autoCenterInSuperviewMargins
 {
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     [constraints addObject:[self autoAlignAxisToSuperviewMarginAxis:ALAxisHorizontal]];
     [constraints addObject:[self autoAlignAxisToSuperviewMarginAxis:ALAxisVertical]];
     return constraints;
@@ -202,7 +202,7 @@
  */
 - (PL__NSArray_of(NSLayoutConstraint *) *)autoPinEdgesToSuperviewEdgesWithInsets:(ALEdgeInsets)insets
 {
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     [constraints addObject:[self autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:insets.top]];
     [constraints addObject:[self autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset:insets.left]];
     [constraints addObject:[self autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:insets.bottom]];
@@ -221,7 +221,7 @@
  */
 - (PL__NSArray_of(NSLayoutConstraint *) *)autoPinEdgesToSuperviewEdgesWithInsets:(ALEdgeInsets)insets excludingEdge:(ALEdge)edge
 {
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     if (edge != ALEdgeTop) {
         [constraints addObject:[self autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:insets.top]];
     }
@@ -281,7 +281,7 @@
  */
 - (PL__NSArray_of(NSLayoutConstraint *) *)autoPinEdgesToSuperviewMargins
 {
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     [constraints addObject:[self autoPinEdgeToSuperviewMargin:ALEdgeTop]];
     [constraints addObject:[self autoPinEdgeToSuperviewMargin:ALEdgeLeading]];
     [constraints addObject:[self autoPinEdgeToSuperviewMargin:ALEdgeBottom]];
@@ -297,7 +297,7 @@
  */
 - (PL__NSArray_of(NSLayoutConstraint *) *)autoPinEdgesToSuperviewMarginsExcludingEdge:(ALEdge)edge
 {
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     if (edge != ALEdgeTop) {
         [constraints addObject:[self autoPinEdgeToSuperviewMargin:ALEdgeTop]];
     }
@@ -486,7 +486,7 @@
  */
 - (PL__NSArray_of(NSLayoutConstraint *) *)autoSetDimensionsToSize:(CGSize)size
 {
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     [constraints addObject:[self autoSetDimension:ALDimensionWidth toSize:size.width]];
     [constraints addObject:[self autoSetDimension:ALDimensionHeight toSize:size.height]];
     return constraints;

--- a/PureLayout/PureLayout/NSArray+PureLayout.m
+++ b/PureLayout/PureLayout/NSArray+PureLayout.m
@@ -121,7 +121,7 @@
 - (PL__NSArray_of(NSLayoutConstraint *) *)autoAlignViewsToEdge:(ALEdge)edge
 {
     NSAssert([self al_containsMinimumNumberOfViews:2], @"This array must contain at least 2 views.");
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     ALView *previousView = nil;
     for (id object in self) {
         if ([object isKindOfClass:[ALView class]]) {
@@ -146,7 +146,7 @@
 - (PL__NSArray_of(NSLayoutConstraint *) *)autoAlignViewsToAxis:(ALAxis)axis
 {
     NSAssert([self al_containsMinimumNumberOfViews:2], @"This array must contain at least 2 views.");
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     ALView *previousView = nil;
     for (id object in self) {
         if ([object isKindOfClass:[ALView class]]) {
@@ -171,7 +171,7 @@
 - (PL__NSArray_of(NSLayoutConstraint *) *)autoMatchViewsDimension:(ALDimension)dimension
 {
     NSAssert([self al_containsMinimumNumberOfViews:2], @"This array must contain at least 2 views.");
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     ALView *previousView = nil;
     for (id object in self) {
         if ([object isKindOfClass:[ALView class]]) {
@@ -197,7 +197,7 @@
 - (PL__NSArray_of(NSLayoutConstraint *) *)autoSetViewsDimension:(ALDimension)dimension toSize:(CGFloat)size
 {
     NSAssert([self al_containsMinimumNumberOfViews:1], @"This array must contain at least 1 view.");
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     for (id object in self) {
         if ([object isKindOfClass:[ALView class]]) {
             ALView *view = (ALView *)object;
@@ -217,7 +217,7 @@
  */
 - (PL__NSArray_of(NSLayoutConstraint *) *)autoSetViewsDimensionsToSize:(CGSize)size
 {
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     [constraints addObjectsFromArray:[self autoSetViewsDimension:ALDimensionWidth toSize:size.width]];
     [constraints addObjectsFromArray:[self autoSetViewsDimension:ALDimensionHeight toSize:size.height]];
     return constraints;
@@ -311,7 +311,7 @@
     CGFloat leadingSpacing = shouldSpaceInsets ? spacing : 0.0;
     CGFloat trailingSpacing = shouldSpaceInsets ? spacing : 0.0;
     
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     ALView *previousView = nil;
     for (id object in self) {
         if ([object isKindOfClass:[ALView class]]) {
@@ -407,7 +407,7 @@
 #endif /* TARGET_OS_IPHONE */
     BOOL shouldFlipOrder = isRightToLeftLayout && (axis != ALAxisVertical); // imitate the effect of leading/trailing when distributing horizontally
     
-    __NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *constraints = [NSMutableArray new];
     PL__NSArray_of(ALView *) *views = [self al_copyViewsOnly];
     NSUInteger numberOfViews = [views count];
     ALView *commonSuperview = [views al_commonSuperviewOfViews];
@@ -493,7 +493,7 @@
  */
 - (PL__NSArray_of(ALView *) *)al_copyViewsOnly
 {
-    __NSMutableArray_of(ALView *) *viewsOnlyArray = [NSMutableArray arrayWithCapacity:[self count]];
+    PL__NSMutableArray_of(ALView *) *viewsOnlyArray = [NSMutableArray arrayWithCapacity:[self count]];
     for (id object in self) {
         if ([object isKindOfClass:[ALView class]]) {
             [viewsOnlyArray addObject:object];

--- a/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.m
+++ b/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.m
@@ -46,7 +46,7 @@
  
  NOTE: Access to this variable is not synchronized (and should only be done on the main thread).
  */
-static __NSMutableArray_of(__NSMutableArray_of(NSLayoutConstraint *) *) *_al_arraysOfCreatedConstraints = nil;
+static PL__NSMutableArray_of(PL__NSMutableArray_of(NSLayoutConstraint *) *) *_al_arraysOfCreatedConstraints = nil;
 
 /**
  A global variable that is set to YES when installing a batch of constraints collected from a call to +[autoCreateAndInstallConstraints].
@@ -59,7 +59,7 @@ static BOOL _al_isInstallingCreatedConstraints = NO;
 /**
  Accessor for the global state that stores arrays of constraints created without being installed.
  */
-+ (__NSMutableArray_of(__NSMutableArray_of(NSLayoutConstraint *) *) *)al_arraysOfCreatedConstraints
++ (PL__NSMutableArray_of(PL__NSMutableArray_of(NSLayoutConstraint *) *) *)al_arraysOfCreatedConstraints
 {
     NSAssert([NSThread isMainThread], @"PureLayout is not thread safe, and must be used exclusively from the main thread.");
     if (!_al_arraysOfCreatedConstraints) {
@@ -71,7 +71,7 @@ static BOOL _al_isInstallingCreatedConstraints = NO;
 /**
  Accessor for the current mutable array of constraints created without being immediately installed.
  */
-+ (__NSMutableArray_of(NSLayoutConstraint *) *)al_currentArrayOfCreatedConstraints
++ (PL__NSMutableArray_of(NSLayoutConstraint *) *)al_currentArrayOfCreatedConstraints
 {
     return [[self al_arraysOfCreatedConstraints] lastObject];
 }
@@ -138,12 +138,12 @@ static BOOL _al_isInstallingCreatedConstraints = NO;
  constraints created by this library (even if automatic constraint installation is being prevented).
  NOTE: Access to this variable is not synchronized (and should only be done on the main thread).
  */
-static __NSMutableArray_of(NSNumber *) *_al_globalConstraintPriorities = nil;
+static PL__NSMutableArray_of(NSNumber *) *_al_globalConstraintPriorities = nil;
 
 /**
  Accessor for the global stack of layout priorities.
  */
-+ (__NSMutableArray_of(NSNumber *) *)al_globalConstraintPriorities
++ (PL__NSMutableArray_of(NSNumber *) *)al_globalConstraintPriorities
 {
     NSAssert([NSThread isMainThread], @"PureLayout is not thread safe, and must be used exclusively from the main thread.");
     if (!_al_globalConstraintPriorities) {
@@ -159,7 +159,7 @@ static __NSMutableArray_of(NSNumber *) *_al_globalConstraintPriorities = nil;
  */
 + (ALLayoutPriority)al_currentGlobalConstraintPriority
 {
-    __NSMutableArray_of(NSNumber *) *globalConstraintPriorities = [self al_globalConstraintPriorities];
+    PL__NSMutableArray_of(NSNumber *) *globalConstraintPriorities = [self al_globalConstraintPriorities];
     if ([globalConstraintPriorities count] == 0) {
         return ALLayoutPriorityRequired;
     }
@@ -207,12 +207,12 @@ static __NSMutableArray_of(NSNumber *) *_al_globalConstraintPriorities = nil;
  constraints created by this library (even if automatic constraint installation is being prevented).
  NOTE: Access to this variable is not synchronized (and should only be done on the main thread).
  */
-static __NSMutableArray_of(NSString *) *_al_globalConstraintIdentifiers = nil;
+static PL__NSMutableArray_of(NSString *) *_al_globalConstraintIdentifiers = nil;
 
 /**
  Accessor for the global state of constraint identifiers.
  */
-+ (__NSMutableArray_of(NSString *) *)al_globalConstraintIdentifiers
++ (PL__NSMutableArray_of(NSString *) *)al_globalConstraintIdentifiers
 {
     NSAssert([NSThread isMainThread], @"PureLayout is not thread safe, and must be used exclusively from the main thread.");
     if (!_al_globalConstraintIdentifiers) {
@@ -228,7 +228,7 @@ static __NSMutableArray_of(NSString *) *_al_globalConstraintIdentifiers = nil;
  */
 + (NSString *)al_currentGlobalConstraintIdentifier
 {
-    __NSMutableArray_of(NSString *) *globalConstraintIdentifiers = [self al_globalConstraintIdentifiers];
+    PL__NSMutableArray_of(NSString *) *globalConstraintIdentifiers = [self al_globalConstraintIdentifiers];
     if ([globalConstraintIdentifiers count] == 0) {
         return nil;
     }

--- a/PureLayout/PureLayout/PureLayout+Internal.h
+++ b/PureLayout/PureLayout/PureLayout+Internal.h
@@ -29,7 +29,7 @@
 
 
 // Using generics with NSMutableArray is so common in the internal implementation of PureLayout that it gets a dedicated preprocessor macro for better readability.
-#define __NSMutableArray_of(type)                   PL__GENERICS(NSMutableArray, type)
+#define PL__NSMutableArray_of(type)                   PL__GENERICS(NSMutableArray, type)
 
 PL__ASSUME_NONNULL_BEGIN
 
@@ -68,7 +68,7 @@ static const CGFloat kMULTIPLIER_MIN_VALUE = (CGFloat)0.00001; // very small flo
 @interface NSLayoutConstraint (PureLayoutInternal)
 
 + (BOOL)al_preventAutomaticConstraintInstallation;
-+ (__NSMutableArray_of(NSLayoutConstraint *) *)al_currentArrayOfCreatedConstraints;
++ (PL__NSMutableArray_of(NSLayoutConstraint *) *)al_currentArrayOfCreatedConstraints;
 + (BOOL)al_isExecutingPriorityConstraintsBlock;
 + (ALLayoutPriority)al_currentGlobalConstraintPriority;
 #if PL__PureLayout_MinBaseSDK_iOS_8_0 || PL__PureLayout_MinBaseSDK_OSX_10_10

--- a/PureLayout/PureLayout/PureLayout+Internal.h
+++ b/PureLayout/PureLayout/PureLayout+Internal.h
@@ -72,7 +72,7 @@ static const CGFloat kMULTIPLIER_MIN_VALUE = (CGFloat)0.00001; // very small flo
 + (BOOL)al_isExecutingPriorityConstraintsBlock;
 + (ALLayoutPriority)al_currentGlobalConstraintPriority;
 #if PL__PureLayout_MinBaseSDK_iOS_8_0 || PL__PureLayout_MinBaseSDK_OSX_10_10
-+ (NSString *)al_currentGlobalConstraintIdentifier;
++ (nullable NSString *)al_currentGlobalConstraintIdentifier;
 #endif /* PL__PureLayout_MinBaseSDK_iOS_8_0 || PL__PureLayout_MinBaseSDK_OSX_10_10 */
 + (void)al_applyGlobalStateToConstraint:(NSLayoutConstraint *)constraint;
 + (NSLayoutAttribute)al_layoutAttributeForAttribute:(ALAttribute)attribute;

--- a/PureLayout/PureLayoutTests/PureLayoutBatchTests.m
+++ b/PureLayout/PureLayoutTests/PureLayoutBatchTests.m
@@ -78,7 +78,7 @@
  */
 - (void)testCreateAndInstallConstraints
 {
-    __NSMutableArray_of(NSLayoutConstraint *) *createdConstraints = [NSMutableArray array];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *createdConstraints = [NSMutableArray array];
     PL__NSArray_of(NSLayoutConstraint *) *returnedConstraints = [NSLayoutConstraint autoCreateAndInstallConstraints:^{
         [createdConstraints addObjectsFromArray:[self.viewA autoPinEdgesToSuperviewEdges]];
         [createdConstraints addObject:[self.viewA_A autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.viewA_A.superview]];
@@ -149,7 +149,7 @@
  */
 - (void)testCreateConstraintsWithoutInstalling
 {
-    __NSMutableArray_of(NSLayoutConstraint *) *createdConstraints = [NSMutableArray array];
+    PL__NSMutableArray_of(NSLayoutConstraint *) *createdConstraints = [NSMutableArray array];
     PL__NSArray_of(NSLayoutConstraint *) *returnedConstraints = [NSLayoutConstraint autoCreateConstraintsWithoutInstalling:^{
         [createdConstraints addObjectsFromArray:[self.viewA autoPinEdgesToSuperviewEdgesWithInsets:ALEdgeInsetsMake(10.0, 10.0, 10.0, 10.0) excludingEdge:ALEdgeBottom]];
         [createdConstraints addObject:[self.viewA_A autoAlignAxis:ALAxisVertical toSameAxisOfView:self.viewA_A.superview]];


### PR DESCRIPTION
Fixes #148 by renaming macro to `PL__NSMutableArray_of` and adds `nullable` annotation to `al_currentGlobalConstraintIdentifier` method.