### PR TITLE
Remove superfluous property setting from the podspec

### DIFF
--- a/PureLayout.podspec
+++ b/PureLayout.podspec
@@ -9,7 +9,6 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.source                = { git: "#{s.homepage}.git", tag: "v#{s.version}" }
   s.source_files          = "#{s.name}/#{s.name}"
-  s.requires_arc          = true
   s.summary               = 'The ultimate API for iOS & OS X Auto Layout — impressively simple, immensely powerful. Objective-C and Swift compatible.'
   s.description  = <<-DESC
     # PureLayout


### PR DESCRIPTION
The `requires_arc` property is `true` by default.