### PR TITLE
Respect autoCreateConstraintsWithoutInstalling for Safe Area Pins

### DIFF
--- a/PureLayout/PureLayout/ALView+PureLayout.m
+++ b/PureLayout/PureLayout/ALView+PureLayout.m
@@ -297,7 +297,7 @@
             }
             break;
     }
-    constraint.active = YES;
+    [constraint autoInstall];
     return constraint;
 #else
     return [self autoPinEdgeToSuperviewEdge:edge withInset:inset relation:relation];


### PR DESCRIPTION
- Respect autoCreateConstraintsWithoutInstalling when pinning an edge to the superview’s safe area.