### PR TITLE
Avoid compiler warnings for deprecated layout guides

### DIFF
--- a/PureLayout/PureLayout/ALView+PureLayout.h
+++ b/PureLayout/PureLayout/ALView+PureLayout.h
@@ -222,6 +222,7 @@ PL__ASSUME_NONNULL_BEGIN
 #pragma mark Pin to Layout Guides (iOS only)
 
 #if TARGET_OS_IPHONE
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_11_0 // Top and bottom layout guides were deprecated in iOS 11
 
 /** Pins the top edge of the view to the top layout guide of the given view controller with an inset. Available on iOS only. */
 - (NSLayoutConstraint *)autoPinToTopLayoutGuideOfViewController:(UIViewController *)viewController withInset:(CGFloat)inset;
@@ -235,6 +236,7 @@ PL__ASSUME_NONNULL_BEGIN
 /** Pins the bottom edge of the view to the bottom layout guide of the given view controller with an inset as a maximum or minimum. Available on iOS only. */
 - (NSLayoutConstraint *)autoPinToBottomLayoutGuideOfViewController:(UIViewController *)viewController withInset:(CGFloat)inset relation:(NSLayoutRelation)relation;
 
+#endif /* __IPHONE_OS_VERSION_MIN_REQUIRED */
 #endif /* TARGET_OS_IPHONE */
 
 @end

--- a/PureLayout/PureLayout/ALView+PureLayout.m
+++ b/PureLayout/PureLayout/ALView+PureLayout.m
@@ -956,7 +956,7 @@
 #pragma mark Pin to Layout Guides
 
 #if TARGET_OS_IPHONE
-
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_11_0 // Top and bottom layout guides were deprecated in iOS 11
 /**
  Pins the top edge of the view to the top layout guide of the given view controller with an inset.
  For compatibility with iOS 6 (where layout guides do not exist), this method will simply pin the top edge of
@@ -1018,6 +1018,7 @@
     }
 }
 
+#endif /* __IPHONE_OS_VERSION_MIN_REQUIRED */
 #endif /* TARGET_OS_IPHONE */
 
 #pragma mark Internal Methods


### PR DESCRIPTION
If the deployment target is set to 11 or greater this prevents compiler warnings for deprecated topLayoutGuide and bottomLayoutGuide. 