### PR TITLE
Fix compiler warnings about enum comparison

### DIFF
--- a/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.m
+++ b/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.m
@@ -373,73 +373,73 @@ static PL__NSMutableArray_of(NSString *) *_al_globalConstraintIdentifiers = nil;
 {
     NSLayoutAttribute layoutAttribute = NSLayoutAttributeNotAnAttribute;
     switch (attribute) {
-        case (ALAttribute)ALEdgeLeft:
+        case ALAttributeLeft:
             layoutAttribute = NSLayoutAttributeLeft;
             break;
-        case (ALAttribute)ALEdgeRight:
+        case ALAttributeRight:
             layoutAttribute = NSLayoutAttributeRight;
             break;
-        case (ALAttribute)ALEdgeTop:
+        case ALAttributeTop:
             layoutAttribute = NSLayoutAttributeTop;
             break;
-        case (ALAttribute)ALEdgeBottom:
+        case ALAttributeBottom:
             layoutAttribute = NSLayoutAttributeBottom;
             break;
-        case (ALAttribute)ALEdgeLeading:
+        case ALAttributeLeading:
             layoutAttribute = NSLayoutAttributeLeading;
             break;
-        case (ALAttribute)ALEdgeTrailing:
+        case ALAttributeTrailing:
             layoutAttribute = NSLayoutAttributeTrailing;
             break;
-        case (ALAttribute)ALDimensionWidth:
+        case ALAttributeWidth:
             layoutAttribute = NSLayoutAttributeWidth;
             break;
-        case (ALAttribute)ALDimensionHeight:
+        case ALAttributeHeight:
             layoutAttribute = NSLayoutAttributeHeight;
             break;
-        case (ALAttribute)ALAxisVertical:
+        case ALAttributeVertical:
             layoutAttribute = NSLayoutAttributeCenterX;
             break;
-        case (ALAttribute)ALAxisHorizontal:
+        case ALAttributeHorizontal:
             layoutAttribute = NSLayoutAttributeCenterY;
             break;
-        case (ALAttribute)ALAxisBaseline: // same value as ALAxisLastBaseline
+        case ALAttributeBaseline: // same value as ALAxisLastBaseline
             layoutAttribute = NSLayoutAttributeBaseline;
             break;
 #if PL__PureLayout_MinBaseSDK_iOS_8_0
-        case (ALAttribute)ALAxisFirstBaseline:
+        case ALAttributeFirstBaseline:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALAxisFirstBaseline is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeFirstBaseline;
             break;
-        case (ALAttribute)ALMarginLeft:
+        case ALAttributeMarginLeft:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALEdgeLeftMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeLeftMargin;
             break;
-        case (ALAttribute)ALMarginRight:
+        case ALAttributeMarginRight:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALEdgeRightMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeRightMargin;
             break;
-        case (ALAttribute)ALMarginTop:
+        case ALAttributeMarginTop:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALEdgeTopMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeTopMargin;
             break;
-        case (ALAttribute)ALMarginBottom:
+        case ALAttributeMarginBottom:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALEdgeBottomMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeBottomMargin;
             break;
-        case (ALAttribute)ALMarginLeading:
+        case ALAttributeMarginLeading:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALEdgeLeadingMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeLeadingMargin;
             break;
-        case (ALAttribute)ALMarginTrailing:
+        case ALAttributeMarginTrailing:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALEdgeTrailingMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeTrailingMargin;
             break;
-        case (ALAttribute)ALMarginAxisVertical:
+        case ALAttributeMarginAxisVertical:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALAxisVerticalMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeCenterXWithinMargins;
             break;
-        case (ALAttribute)ALMarginAxisHorizontal:
+        case ALAttributeMarginAxisHorizontal:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALAxisHorizontalMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeCenterYWithinMargins;
             break;

--- a/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.m
+++ b/PureLayout/PureLayout/NSLayoutConstraint+PureLayout.m
@@ -373,73 +373,73 @@ static PL__NSMutableArray_of(NSString *) *_al_globalConstraintIdentifiers = nil;
 {
     NSLayoutAttribute layoutAttribute = NSLayoutAttributeNotAnAttribute;
     switch (attribute) {
-        case ALEdgeLeft:
+        case (ALAttribute)ALEdgeLeft:
             layoutAttribute = NSLayoutAttributeLeft;
             break;
-        case ALEdgeRight:
+        case (ALAttribute)ALEdgeRight:
             layoutAttribute = NSLayoutAttributeRight;
             break;
-        case ALEdgeTop:
+        case (ALAttribute)ALEdgeTop:
             layoutAttribute = NSLayoutAttributeTop;
             break;
-        case ALEdgeBottom:
+        case (ALAttribute)ALEdgeBottom:
             layoutAttribute = NSLayoutAttributeBottom;
             break;
-        case ALEdgeLeading:
+        case (ALAttribute)ALEdgeLeading:
             layoutAttribute = NSLayoutAttributeLeading;
             break;
-        case ALEdgeTrailing:
+        case (ALAttribute)ALEdgeTrailing:
             layoutAttribute = NSLayoutAttributeTrailing;
             break;
-        case ALDimensionWidth:
+        case (ALAttribute)ALDimensionWidth:
             layoutAttribute = NSLayoutAttributeWidth;
             break;
-        case ALDimensionHeight:
+        case (ALAttribute)ALDimensionHeight:
             layoutAttribute = NSLayoutAttributeHeight;
             break;
-        case ALAxisVertical:
+        case (ALAttribute)ALAxisVertical:
             layoutAttribute = NSLayoutAttributeCenterX;
             break;
-        case ALAxisHorizontal:
+        case (ALAttribute)ALAxisHorizontal:
             layoutAttribute = NSLayoutAttributeCenterY;
             break;
-        case ALAxisBaseline: // same value as ALAxisLastBaseline
+        case (ALAttribute)ALAxisBaseline: // same value as ALAxisLastBaseline
             layoutAttribute = NSLayoutAttributeBaseline;
             break;
 #if PL__PureLayout_MinBaseSDK_iOS_8_0
-        case ALAxisFirstBaseline:
+        case (ALAttribute)ALAxisFirstBaseline:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALAxisFirstBaseline is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeFirstBaseline;
             break;
-        case ALMarginLeft:
+        case (ALAttribute)ALMarginLeft:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALEdgeLeftMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeLeftMargin;
             break;
-        case ALMarginRight:
+        case (ALAttribute)ALMarginRight:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALEdgeRightMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeRightMargin;
             break;
-        case ALMarginTop:
+        case (ALAttribute)ALMarginTop:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALEdgeTopMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeTopMargin;
             break;
-        case ALMarginBottom:
+        case (ALAttribute)ALMarginBottom:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALEdgeBottomMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeBottomMargin;
             break;
-        case ALMarginLeading:
+        case (ALAttribute)ALMarginLeading:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALEdgeLeadingMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeLeadingMargin;
             break;
-        case ALMarginTrailing:
+        case (ALAttribute)ALMarginTrailing:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALEdgeTrailingMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeTrailingMargin;
             break;
-        case ALMarginAxisVertical:
+        case (ALAttribute)ALMarginAxisVertical:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALAxisVerticalMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeCenterXWithinMargins;
             break;
-        case ALMarginAxisHorizontal:
+        case (ALAttribute)ALMarginAxisHorizontal:
             NSAssert(PL__PureLayout_MinSysVer_iOS_8_0, @"ALAxisHorizontalMargin is only supported on iOS 8.0 or higher.");
             layoutAttribute = NSLayoutAttributeCenterYWithinMargins;
             break;


### PR DESCRIPTION
This silences [`-Wenum-compare-switch`](https://clang.llvm.org/docs/DiagnosticsReference.html#wenum-compare-switch). Clang documentation says it's on by default, so I'm not sure why it's not showing up in the PureLayout example projects, but it is in mine. It's harmless in this case, and easy to silence.

Alternatively it could use the `ALAttribute` values (i.e. `ALAttributeLeft` instead of `ALEdgeLeft`).